### PR TITLE
Fixed typos and styling

### DIFF
--- a/challenge.md
+++ b/challenge.md
@@ -1,6 +1,6 @@
 # Extension CHALLENGES
 
-## Syntax defenitions
+## Syntax definitions
 
 - `!argument`: required
 - `[arguments]`: list of arguments, __not__ space separated
@@ -24,7 +24,7 @@ The request (CHALLENGE REQUEST) method requests a challenge with a specific play
 
 ### Confirm
 
-The confirm (CHALLENGE CONFIRM) confirms a challenge request. This requiest needs to have happened in order to confirm.
+The confirm (CHALLENGE CONFIRM) confirms a challenge request. This request needs to have happened in order to confirm.
 
 #### Syntax
 

--- a/chat.md
+++ b/chat.md
@@ -1,6 +1,6 @@
 # Extension CHAT
 
-## Syntax defenitions
+## Syntax definitions
 
 - `!argument`: required
 - `[arguments]`: list of arguments, __not__ space separated

--- a/errors.md
+++ b/errors.md
@@ -62,9 +62,9 @@ A user with the same name is already connected.
 
 ### extension does not support (020)
 
-The extension does not exist and therefore cannot be applied (all extensions)
+The extension does not exist and therefore cannot be applied (all extensions).
 
 ### user does not support required extension (191)
 
-The remote user does not use the extension, and therefore the method that was called cannot continue
+The remote user does not use the extension, and therefore the method that was called cannot continue.
 

--- a/leaderboard.md
+++ b/leaderboard.md
@@ -1,6 +1,6 @@
 # Extension LEADERBOARD
 
-## Syntax defenitions
+## Syntax definitions
 
 - `!argument`: required
 - `[arguments]`: list of arguments, __not__ space separated
@@ -14,7 +14,7 @@ The LEADERBOARD extension has the following format:
 
 ## Client -> Server
 
-#### User
+### User
 
 The user (LEADERBOARD USER) command requests a list of scores for the given user.
 
@@ -36,7 +36,7 @@ The all (LEADERBOARD ALL) command lists all users and their scores
 
 ## Server -> Client
 
-### Request
+### List
 
 The list (LEADERBOARD LIST) command returns a list of users, and for each user a list of scores. The same syntax may be used when returning a single user in response to a client LEADERBOARD USER request.
 


### PR DESCRIPTION
grand issue was the Request title header in LeaderBoard, for consistency
changed it to List, because the command is LEADERBOARD LIST, not
LEADERBOARD REQUEST.